### PR TITLE
Add `mapResults` option.

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -9,6 +9,7 @@
     }
   },
   "plugins": [
+    "transform-class-properties",
     "syntax-object-rest-spread",
     "transform-object-rest-spread"
   ],

--- a/.flowconfig
+++ b/.flowconfig
@@ -2,11 +2,15 @@
 0.67.1
 
 [ignore]
-.*\.flow
-[include]
+.*\.flow$
 
-[libs]
+[include]
 
 [lints]
 
+[libs]
+
 [options]
+emoji=true
+include_warnings=true
+suppress_comment=\\(.\\|\n\\)*\\$ExpectError

--- a/.flowconfig
+++ b/.flowconfig
@@ -1,3 +1,6 @@
+[version]
+0.67.1
+
 [ignore]
 .*\.flow
 [include]

--- a/README.md
+++ b/README.md
@@ -28,12 +28,10 @@ module.exports = {
   // ...
   plugins: [
     new PagesPlugin({
-      name: '[path][name].[ext]',
-      paths: [
-        '/',
-      ],
+      // Required Config
       mapStatsToProps: (stats) => {
-        return {stats: stats};
+        // Map webpack stats object to render function props
+        return {stats: stats.toJson(/* webpack toJson options*/)};
       },
       render: (props) => {
         const {stats, path} = props;
@@ -47,7 +45,21 @@ module.exports = {
             </body>
           </html>
         `
-        return {markup};
+
+        const result = {markup, /* status, redirect */}
+        return result;
+      },
+      // Optional Config
+      paths: ['/'], // Define initial seed routes
+      mapResultToFilename(result) {
+        // Map rendered path to output file name
+        return result.path;
+      },
+      mapResults(results, compilation) {
+        // Intercept generated files before emit
+        return results.map((result) => {
+          return result;
+        });
       },
     }),
   ],

--- a/package-lock.json
+++ b/package-lock.json
@@ -3043,9 +3043,9 @@
       }
     },
     "flow-bin": {
-      "version": "0.56.0",
-      "resolved": "https://registry.npmjs.org/flow-bin/-/flow-bin-0.56.0.tgz",
-      "integrity": "sha1-zkMJIgOjRLqb9jwMq+ldlRRfbK0=",
+      "version": "0.67.1",
+      "resolved": "https://registry.npmjs.org/flow-bin/-/flow-bin-0.67.1.tgz",
+      "integrity": "sha512-jZwanQrtgVRDKs3Le3MmD44YTZSzWkpuUeMv4ZckDOuaa2VQ41ttuxqzxErRdTr/ZSs+J1L2SQW6NKO+D4t2Vw==",
       "dev": true
     },
     "for-in": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -805,6 +805,12 @@
       "integrity": "sha1-ytnK0RkbWtY0vzCuCHI5HgZHvpU=",
       "dev": true
     },
+    "babel-plugin-syntax-class-properties": {
+      "version": "6.13.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-syntax-class-properties/-/babel-plugin-syntax-class-properties-6.13.0.tgz",
+      "integrity": "sha1-1+sjt5oxf4VDlixQW4J8fWysJ94=",
+      "dev": true
+    },
     "babel-plugin-syntax-exponentiation-operator": {
       "version": "6.13.0",
       "resolved": "https://registry.npmjs.org/babel-plugin-syntax-exponentiation-operator/-/babel-plugin-syntax-exponentiation-operator-6.13.0.tgz",
@@ -848,6 +854,18 @@
         "babel-helper-remap-async-to-generator": "6.24.1",
         "babel-plugin-syntax-async-functions": "6.13.0",
         "babel-runtime": "6.26.0"
+      }
+    },
+    "babel-plugin-transform-class-properties": {
+      "version": "6.24.1",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-class-properties/-/babel-plugin-transform-class-properties-6.24.1.tgz",
+      "integrity": "sha1-anl2PqYdM9NvN7YRqp3vgagbRqw=",
+      "dev": true,
+      "requires": {
+        "babel-helper-function-name": "6.24.1",
+        "babel-plugin-syntax-class-properties": "6.13.0",
+        "babel-runtime": "6.26.0",
+        "babel-template": "6.26.0"
       }
     },
     "babel-plugin-transform-es2015-arrow-functions": {
@@ -1307,7 +1325,8 @@
     "big.js": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/big.js/-/big.js-3.2.0.tgz",
-      "integrity": "sha512-+hN/Zh2D08Mx65pZ/4g5bsmNiZUuChDiQfTUQ7qJr4/kuopCr88xZsAXv6mBoZEsUI4OuGHlX59qE94K2mMW8Q=="
+      "integrity": "sha512-+hN/Zh2D08Mx65pZ/4g5bsmNiZUuChDiQfTUQ7qJr4/kuopCr88xZsAXv6mBoZEsUI4OuGHlX59qE94K2mMW8Q==",
+      "dev": true
     },
     "binary-extensions": {
       "version": "1.10.0",
@@ -2206,7 +2225,8 @@
     "emojis-list": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/emojis-list/-/emojis-list-2.1.0.tgz",
-      "integrity": "sha1-TapNnbAPmBmIDHn6RXrlsJof04k="
+      "integrity": "sha1-TapNnbAPmBmIDHn6RXrlsJof04k=",
+      "dev": true
     },
     "encoding": {
       "version": "0.1.12",
@@ -5250,7 +5270,8 @@
     "json5": {
       "version": "0.5.1",
       "resolved": "https://registry.npmjs.org/json5/-/json5-0.5.1.tgz",
-      "integrity": "sha1-Hq3nrMASA0rYTiOWdn6tn6VJWCE="
+      "integrity": "sha1-Hq3nrMASA0rYTiOWdn6tn6VJWCE=",
+      "dev": true
     },
     "jsonify": {
       "version": "0.0.0",
@@ -5339,6 +5360,7 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-1.1.0.tgz",
       "integrity": "sha1-yYrvSIvM7aL/teLeZG1qdUQp9c0=",
+      "dev": true,
       "requires": {
         "big.js": "3.2.0",
         "emojis-list": "2.1.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -3867,14 +3867,6 @@
             }
           }
         },
-        "string_decoder": {
-          "version": "1.0.1",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "safe-buffer": "5.0.1"
-          }
-        },
         "string-width": {
           "version": "1.0.2",
           "bundled": true,
@@ -3883,6 +3875,14 @@
             "code-point-at": "1.1.0",
             "is-fullwidth-code-point": "1.0.0",
             "strip-ansi": "3.0.1"
+          }
+        },
+        "string_decoder": {
+          "version": "1.0.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "safe-buffer": "5.0.1"
           }
         },
         "stringstream": {
@@ -6880,14 +6880,6 @@
         "xtend": "4.0.1"
       }
     },
-    "string_decoder": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
-      "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
-      "requires": {
-        "safe-buffer": "5.1.1"
-      }
-    },
     "string-length": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/string-length/-/string-length-1.0.1.tgz",
@@ -6912,6 +6904,14 @@
         "code-point-at": "1.1.0",
         "is-fullwidth-code-point": "1.0.0",
         "strip-ansi": "3.0.1"
+      }
+    },
+    "string_decoder": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
+      "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
+      "requires": {
+        "safe-buffer": "5.1.1"
       }
     },
     "stringstream": {

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "chai": "^3.4.1",
     "eslint": "^4.5.0",
     "eslint-config-metalab": "^7.0.1",
-    "flow-bin": "^0.56.0",
+    "flow-bin": "^0.67.1",
     "mocha": "^2.3.4",
     "ncp": "^2.0.0",
     "renamer": "^0.6.1",

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "babel-core": "^6.3.26",
     "babel-plugin-syntax-object-rest-spread": "^6.13.0",
     "babel-plugin-transform-adana": "^0.5.10",
+    "babel-plugin-transform-class-properties": "^6.24.1",
     "babel-plugin-transform-object-rest-spread": "^6.26.0",
     "babel-preset-env": "^1.6.0",
     "babel-preset-flow": "^6.23.0",
@@ -43,7 +44,6 @@
     "webpack": ">=1"
   },
   "dependencies": {
-    "cheerio": "^1.0.0-rc.2",
-    "loader-utils": "^1.1.0"
+    "cheerio": "^1.0.0-rc.2"
   }
 }

--- a/package.json
+++ b/package.json
@@ -2,14 +2,17 @@
   "name": "pages-webpack-plugin",
   "version": "0.1.0",
   "author": "Izaak Schroeder <izaak.schroeder@gmail.com>",
-  "main": "PagesPlugin.js",
   "license": "CC0-1.0",
+  "main": "lib/PagesPlugin.js",
+  "files": [
+    "lib",
+    "src"
+  ],
   "scripts": {
-    "prepublish": "npm run clean && npm run copy && npm run build && npm run import",
+    "prepublish": "npm run clean && npm run copy && npm run build",
     "clean": "./node_modules/.bin/rimraf lib ./*.js ./*.map ./*.flow internal",
     "build": "./node_modules/.bin/babel --copy-files -s -d lib src",
     "copy": "./node_modules/.bin/ncp src lib && ./node_modules/.bin/renamer --regex --find '$' --replace '.flow' 'lib/**/*.js'",
-    "import": "./node_modules/.bin/ncp lib .",
     "test": "npm run lint && npm run spec && npm run flow",
     "spec": "NODE_ENV=test ./node_modules/.bin/_mocha -r adana-dump --compilers js:babel-core/register -R spec --recursive test/spec",
     "lint": "./node_modules/.bin/eslint .",

--- a/src/PagesPlugin.js
+++ b/src/PagesPlugin.js
@@ -1,122 +1,202 @@
 // @flow
+
 import cheerio from 'cheerio';
-import loaderUtils from 'loader-utils';
+import path from 'path';
+import url from 'url';
 
 type RenderResult = {
-  markup: string
-}
+  markup: string,
+  redirect?: string,
+  status?: number,
+};
 
-type RenderFunction = (props: Object) => (RenderResult | Promise<RenderResult>);
-
-type Options = {
-  name: string,
-  mapStatsToProps: (stats: Object) => Object,
-  render: RenderFunction,
-  paths: Array<string>,
-}
-
-type OutputResult = {
+type OutputResult<T: RenderResult> = {
+  ...T,
   markup: string,
   path: string,
 };
 
-type DoItOptions = {
-  render: RenderFunction,
-  props: Object,
-  paths: Array<string>,
+type FinalResult<T: RenderResult> = {
+  ...T,
+  markup: string,
+  path: string,
+  filename: string,
 };
 
-const doIt = ({
-  render,
-  props,
-  paths = ['/'],
-}: DoItOptions) => {
-  const pathMap = {};
-  const renderPaths = (
-    results: Array<OutputResult>,
-    paths: Array<string>
-  ): Promise<Array<OutputResult>> => {
-    if (paths.length === 0) {
-      return Promise.resolve(results);
-    }
-    const next = [];
-    const newResults = results.slice();
-    return paths.reduce((previous: Promise<*>, path: string) => {
-      if (pathMap[path]) {
-        return previous;
-      }
-      pathMap[path] = true;
-      return previous.then(() => {
-        const result: Promise<RenderResult> = (
-          Promise.resolve(render({path, ...props}))
-        );
-        return result.then(({markup}) => {
-          // TODO: ^ Check `statusCode`, `redirect` ?? etc. and not generate
-          // pages that have e.g. 404 or 500 errors.
-          newResults.push({markup, path});
-          const $ = cheerio.load(markup);
-          $('a[href^="/"]').each((i, elem) => {
-            const path = $(elem).attr('href');
-            next.push(path);
-          });
-        });
-      });
-    }, Promise.resolve()).then(() => {
-      return renderPaths(newResults, next);
-    });
+type Render<T, P> = ({...P, path: string}) => Promise<T> | T;
+type MapResults<T> = (Array<FinalResult<T>>, Object) => Array<FinalResult<T>>;
+type mapResultToFilename<T> = (OutputResult<T>) => string;
+
+type Options<T: RenderResult, P: Object> = {
+  mapStatsToProps: (stats: Object) => P,
+  render: Render<T, P>,
+  mapResults?: MapResults<T>,
+  paths?: Array<string>,
+};
+
+class PagesPlugin<T: RenderResult, P: Object> {
+  options: {
+    mapStatsToProps: (stats: Object) => P,
+    render: Render<T, P>,
+    mapResults: MapResults<T>,
+    mapResultToFilename: mapResultToFilename<T>,
+    paths: Array<string>,
   };
-  return renderPaths([], paths);
-};
 
-class PagesPlugin {
-  options: Options;
+  constructor(options: Options<T, P>) {
+    this.options = {
+      paths: ['/'],
+      mapResults: (results, _compilation) => results,
+      mapResultToFilename: (result) => result.path,
+      ...options,
+    };
 
-  constructor(options: Options) {
-    this.options = options;
-  }
-
-  getName(resourcePath: string, options: Object) {
-    return loaderUtils.interpolateName(
-      {resourcePath},
-      this.options.name,
-      options
-    ).replace(/^\.\//, '');
-  }
-
-  normalizePath(path: string) {
-    if (path.charAt(0) !== '/') {
-      throw new TypeError();
+    if (typeof this.options.mapStatsToProps !== 'function') {
+      throw new TypeError(
+        'PagesPlugin options must contain `mapStatsToProps` function.',
+      );
     }
-    return `${path.substr(1)}/index.html`
-      .replace(/^\//, './')
-      .replace(/\/\//g, '/');
+
+    if (typeof this.options.render !== 'function') {
+      throw new TypeError(
+        'PagesPlugin options must contain `render` function.',
+      );
+    }
   }
 
-  apply(compiler: any) {
-    const {mapStatsToProps, render, paths} = this.options;
-    compiler.plugin('emit', (compilation, callback) => {
-      const stats = compilation.getStats().toJson();
-      doIt({
-        render,
-        props: mapStatsToProps(stats),
-        paths: paths,
-      }).then((results) => {
-        results.forEach((result) => {
-          const path = this.getName(this.normalizePath(result.path), {
-            content: result.markup,
+  normalizePath(pathname: string) {
+    const parts = path.parse(pathname);
+    const {name, dir, ext} = parts;
+
+    if (ext) {
+      return pathname;
+    }
+
+    return path.join(dir, name, 'index.html');
+  }
+
+  parsePathsFromMarkup(markup: string): Array<string> {
+    const $ = cheerio.load(markup);
+    const links = $('a[href]');
+
+    const paths = [];
+
+    links.each((i, element) => {
+      const href = $(element).attr('href');
+      const {pathname, host} = url.parse(href);
+
+      if (
+        !paths.indexOf(pathname) !== -1 &&
+        pathname &&
+        !host &&
+        !/^\/\//.test(href)
+      ) {
+        paths.push(path.normalize(pathname));
+      }
+    });
+
+    return paths;
+  }
+
+  isValidPath(pathname: string) {
+    return /^\//.test(pathname);
+  }
+
+  resolvePath(currentPath: string, pathname: string) {
+    if (/^\//.test(pathname)) return pathname;
+
+    const dirParts = currentPath.split(/\/+/).slice(1);
+    if (dirParts.length !== 0 && /\./.test(dirParts[dirParts.length - 1])) {
+      dirParts.pop();
+    }
+
+    const pathParts = pathname.split(/\/+/).filter((part) => part !== '.');
+
+    let atRoot = false;
+
+    while (pathParts[0] === '..') {
+      pathParts.shift();
+      atRoot = atRoot || dirParts.length === 0;
+
+      if (atRoot) dirParts.push('..');
+      else dirParts.pop();
+    }
+
+    return `/${path.join(...dirParts, ...pathParts)}`;
+  }
+
+  renderPages(
+    props: P,
+    paths: Array<string>,
+    renderedPaths: Array<string> = [],
+    results: Array<OutputResult<T>> = [],
+  ): Promise<Array<OutputResult<T>>> {
+    if (paths.length === 0) return Promise.resolve(results);
+
+    let discoveredPaths = [];
+    return paths
+      .reduce((previous, currentPath) => {
+        const normalizedPath = this.normalizePath(currentPath);
+
+        if (renderedPaths.indexOf(normalizedPath) !== -1) return previous;
+
+        renderedPaths.push(normalizedPath);
+
+        return previous
+          .then(() => this.options.render({...props, path: currentPath}))
+          .then((result) => {
+            // TODO: ^ Check `statusCode`, `redirect` ?? etc. and not generate
+            // pages that have e.g. 404 or 500 errors.
+            results.push({...result, path: currentPath});
+
+            discoveredPaths = discoveredPaths.concat(
+              this.parsePathsFromMarkup(result.markup)
+                .map((pathname) => this.resolvePath(currentPath, pathname))
+                .filter((pathname) => this.isValidPath(pathname)),
+            );
           });
-          compilation.assets[path] = {
-            source: function() {
-              return result.markup;
-            },
-            size: function() {
-              return result.markup.length;
-            },
+      }, Promise.resolve())
+      .then(() =>
+        this.renderPages(props, discoveredPaths, renderedPaths, results)
+      );
+  }
+
+  handleEmit = (compilation: Object, done: (?Error) => void) => {
+    const {
+      mapResultToFilename,
+      mapStatsToProps,
+      mapResults,
+      paths,
+    } = this.options;
+
+    const stats = compilation.getStats();
+
+    const preparedPaths = paths
+      .filter((pathname) => !/\.\.\//.test(pathname))
+      .map((pathname) => path.join('/', pathname));
+
+    this.renderPages(mapStatsToProps(stats), preparedPaths)
+      .then((results) =>
+        results.map((result) => ({
+          ...result,
+          filename: this.normalizePath(mapResultToFilename(result)).slice(1),
+        })),
+      )
+      .then((results) => mapResults(results, compilation))
+      .then((results) => {
+        results.forEach((result) => {
+          compilation.assets[result.filename] = {
+            source: () => result.markup,
+            size: () => result.markup.length,
           };
         });
-        callback();
-      }).catch(callback);
-    });
+        done();
+      })
+      .catch(done);
+  };
+
+  apply(compiler: Object) {
+    compiler.plugin('emit', this.handleEmit);
   }
 }
 

--- a/test/PagesPlugin.flowtest.js
+++ b/test/PagesPlugin.flowtest.js
@@ -1,0 +1,48 @@
+// @flow
+
+import PagesPlugin from '../src/PagesPlugin';
+
+let _;
+
+_ = new PagesPlugin({
+  mapStatsToProps(stats) {
+    return {stats};
+  },
+  render(result) {
+    (result.path: string);
+
+    // $ExpectError
+    (result.path: number);
+
+    return {markup: '', redirect: '/', status: 200, foo: 'bar'};
+  },
+  mapResults(results) {
+    (results: Array<Object>);
+    // $ExpectError
+    (results: void);
+
+    return results.map((result) => {
+      (result.foo: string);
+      // $ExpectError
+      (result.foo: number);
+      return result;
+    });
+  },
+});
+
+_ = new PagesPlugin({
+  mapStatsToProps(stats) {
+    return {stats};
+  },
+  render() {
+    return Promise.resolve({markup: '', redirect: '/', foo: 'bar'});
+  },
+  mapResults(results) {
+    return results.map((result) => {
+      (result.foo: string);
+      // $ExpectError
+      (result.foo: number);
+      return result;
+    });
+  },
+});

--- a/test/spec/PagesPlugin.spec.js
+++ b/test/spec/PagesPlugin.spec.js
@@ -11,6 +11,15 @@ const renderBody = (path) => {
     return 'See all our <a href="/products">Products</a>.';
   case '/products':
     return 'We have the hugest products.';
+  case '/foo':
+  case '/foo.html':
+    return 'Foo';
+  case '/empty':
+    return '<a href="">empty</a>';
+  case '/url':
+    return '<a href="//foo.com/bar">url</a>';
+  case '/relative':
+    return '<a href="./">url1</a><a href="..">url2</a>';
   default:
     return 'Page not found.';
   }
@@ -18,11 +27,9 @@ const renderBody = (path) => {
 
 const baseConfig = {
   name: '[path][name].[ext]',
-  paths: [
-    '/',
-  ],
+  paths: ['/'],
   mapStatsToProps: (stats) => {
-    return {stats: stats};
+    return {stats: stats.toJson()};
   },
   render: (props) => {
     const {stats, path} = props;
@@ -48,10 +55,10 @@ const execWebpack = (config) => {
       const json = stats.toJson();
       const index = {};
       json.assets.forEach((asset) => {
-        index[asset.name] = fs.readFileSync(path.join(
-          config.output.path,
-          asset.name,
-        ), 'utf8');
+        index[asset.name] = fs.readFileSync(
+          path.join(config.output.path, asset.name),
+          'utf8'
+        );
       });
       resolve(index);
     });
@@ -64,10 +71,80 @@ describe('PagesPlugin', () => {
       ...baseConfig,
     });
     return execWebpack(config).then((result) => {
-      expect(result).to.have.property('index.html')
+      expect(result)
+        .to.have.property('index.html')
         .to.contain('See all');
-      expect(result).to.have.property('products/index.html')
+      expect(result)
+        .to.have.property('products/index.html')
         .to.contain('We have the hugest');
+    });
+  });
+
+  it('should fail with no `render`', () => {
+    expect(() =>
+      createConfig(PagesPlugin, {
+        mapStatsToProps: () => {},
+      })
+    ).to.throw(TypeError);
+  });
+  it('should fail with no `mapStatsToProps`', () => {
+    expect(() =>
+      createConfig(PagesPlugin, {
+        render: () => {},
+      })
+    ).to.throw(TypeError);
+  });
+  it('should resolve relative paths', () => {
+    const config = createConfig(PagesPlugin, {
+      ...baseConfig,
+      paths: ['/foo/baz/qux/../..', '/foo/bar/..'],
+    });
+    return execWebpack(config).then((result) => {
+      // TODO: Check this better
+      expect(result)
+        .to.have.property('foo/index.html')
+        .to.contain('Foo');
+    });
+  });
+  it('should resolve relative paths 2', () => {
+    const config = createConfig(PagesPlugin, {
+      ...baseConfig,
+      paths: ['/relative'],
+    });
+    return execWebpack(config).then((result) => {
+      // TODO: Check this better
+      expect(result).to.have.property('index.html');
+      expect(result).to.have.property('relative/index.html');
+    });
+  });
+  it('should preserve extensions', () => {
+    const config = createConfig(PagesPlugin, {
+      ...baseConfig,
+      paths: ['/foo.html'],
+    });
+    return execWebpack(config).then((result) => {
+      // TODO: Check this better
+      expect(result)
+        .to.have.property('foo.html')
+        .to.contain('Foo');
+    });
+  });
+  it('should ignore empty paths', () => {
+    const config = createConfig(PagesPlugin, {
+      ...baseConfig,
+      paths: ['/empty'],
+    });
+    return execWebpack(config).then((result) => {
+      expect(Object.keys(result).length).to.equal(1);
+    });
+  });
+  it('should ignore protocols', () => {
+    const config = createConfig(PagesPlugin, {
+      ...baseConfig,
+      paths: ['/url'],
+    });
+    return execWebpack(config).then((result) => {
+      expect(Object.keys(result).length).to.equal(1);
     });
   });
 });


### PR DESCRIPTION
**Changes**
- Clean up script to publish only necessary files to npm.
- Add `mapResults` option (closes #2)
- Add `getFilename` option and removed use of `loaderUtils.interpolateName` (closes #1)
- Preserve file name of rendered path (closes #4)
- Add generic class types to allow accurate typing between config functions.
- Improved support for relative `href` attributes in crawled markup.
- Change `mapStatsToProps` signature to receive raw stats object, allowing for custom json conversion.
- Updated visited record mechanism to consider the paths `/foo/bar` and `/foo/bar/index.html` to be the same.